### PR TITLE
Properly scope the reference to the Stat class.

### DIFF
--- a/lib/graylog2-resque/failure_handler.rb
+++ b/lib/graylog2-resque/failure_handler.rb
@@ -63,7 +63,7 @@ module Graylog2
       def self.count
         # We can't get the total # of errors from graylog so we fake it
         # by asking Resque how many errors it has seen.
-        Stat[:failed]
+        ::Resque::Stat[:failed]
       end
 
     end


### PR DESCRIPTION
Without this change, resque-web fails to start up if the graylog failure handler is the first in the list.  This is because it cannot find the Stat class.
